### PR TITLE
Enable linux-ppc64le platform

### DIFF
--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,0 +1,18 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -40,6 +40,15 @@ jobs:
             tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+          - CONFIG: linux_ppc64le_
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
     steps:
 
     - name: Checkout code

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,6 +4,8 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: "2"
+build_platform:
+  linux_ppc64le: linux_64
 provider:
   linux_aarch64: default
   osx_arm64: default

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,14 +1,14 @@
+build_platform:
+  linux_ppc64le: linux_64
+conda_build:
+  pkg_format: "2"
+conda_build_tool: rattler-build
 conda_forge_output_validation: true
+conda_install_tool: pixi
 github:
   branch_name: main
   tooling_branch_name: main
-conda_build:
-  pkg_format: "2"
-build_platform:
-  linux_ppc64le: linux_64
 provider:
   linux_aarch64: default
   osx_arm64: default
 test: native_and_emulated
-conda_install_tool: pixi
-conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -35,6 +35,12 @@ description = "Build libimagequant-feedstock with variant linux_aarch64_ directl
 [tasks."inspect-linux_aarch64_"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_.yaml"
 description = "List contents of libimagequant-feedstock packages built for variant linux_aarch64_"
+[tasks."build-linux_ppc64le_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_.yaml"
+description = "Build libimagequant-feedstock with variant linux_ppc64le_ directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_.yaml"
+description = "List contents of libimagequant-feedstock packages built for variant linux_ppc64le_"
 [tasks."build-osx_64_"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_.yaml"
 description = "Build libimagequant-feedstock with variant osx_64_ directly (without setup scripts)"


### PR DESCRIPTION
I added linux-ppc64le because it is missing.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
